### PR TITLE
clj-kondo exports

### DIFF
--- a/resources/clj-kondo.exports/teknql/systemic/config.edn
+++ b/resources/clj-kondo.exports/teknql/systemic/config.edn
@@ -1,0 +1,1 @@
+{:lint-as {systemic.core/defsys clojure.core/def}}


### PR DESCRIPTION
This should make the config importable just by adding "teknql/systemic" in `:config-paths` in your own `config.edn` file.