### PR TITLE
fix: remove cyclic self-dependency

### DIFF
--- a/src/systemic/core.clj
+++ b/src/systemic/core.clj
@@ -1,6 +1,5 @@
 (ns systemic.core
   (:require [clojure.set :as set]
-            [systemic.core :as sut]
             [systemic.internal :as internal]))
 
 (def ^{:dynamic true :no-doc true} *registry*


### PR DESCRIPTION
Looks like this was introduced by accident, and likely shouldn't be
here. It breaks usage from at least a bb-based uberjar.