### PR TITLE
fix: add resources to path so that clj-kondo export works

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,4 +1,4 @@
-{:paths ["src"]
+{:paths ["src" "resources"]
  :pablo/config
  {:github      "teknql/systemic"
   :desc        "Application state management for Clojure"


### PR DESCRIPTION
hi, 

91fe474397bd88e956bd4166027dd75a2f205835 introduced clj-kondo export but forgot to add resources to path ,thus running cmd like `clj-kondo --lint "$(clojure -Spath)" --copy-configs --skip-lint` won't work when adding systemic as git dep.

https://github.com/clj-kondo/clj-kondo/blob/master/doc/config.md#sample-exports

